### PR TITLE
fix: dependency to change to ddgs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "requests>=2.28.0,<2.32.0",
     "urllib3>=1.26.0,<2.0.0",
     "beautifulsoup4>=4.11.0",
-    "duckduckgo-search>=8.0.2",
+    "ddgs>=9.5.2",
 ]
 
 [project.optional-dependencies]

--- a/src/duckduckgo_mcp/_version.py
+++ b/src/duckduckgo_mcp/_version.py
@@ -17,5 +17,5 @@ __version__: str
 __version_tuple__: VERSION_TUPLE
 version_tuple: VERSION_TUPLE
 
-__version__ = version = '1.1.post0'
-__version_tuple__ = version_tuple = (1, 1, 'post0')
+__version__ = version = '1.2.post0'
+__version_tuple__ = version_tuple = (1, 2, 'post0')

--- a/src/duckduckgo_mcp/duckduckgo_search.py
+++ b/src/duckduckgo_mcp/duckduckgo_search.py
@@ -6,80 +6,88 @@ This tool allows searching the web using DuckDuckGo through the MCP (Model Conte
 It integrates with the duckduckgo_search library to provide reliable search results.
 """
 
-import sys
+import argparse
 import json
 import logging
-import argparse
-from typing import Dict, Any, List, Optional
+
+from ddgs import DDGS
+from ddgs.exceptions import DDGSException
 from fastmcp import FastMCP
-from duckduckgo_search import DDGS
-from duckduckgo_search.exceptions import DuckDuckGoSearchException
+
+
+# Threshold for switching to 'lite' backend based on query length
+QUERY_LENGTH_LITE_BACKEND_THRESHOLD = 100
+
+
+def _format_ddg_results(results: list[dict]) -> list[dict[str, str]]:
+    """
+    Helper function to format DuckDuckGo search results.
+    """
+    return [
+        {
+            "title": result.get("title", ""),
+            "url": result.get("href", ""),
+            "snippet": result.get("body", ""),
+        }
+        for result in results
+    ]
+
 
 # Set up logging
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
-)
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
 
 # Create the MCP server
 mcp = FastMCP(name="duckduckgo_search")
 
-def search_duckduckgo(query: str, max_results: int = 5, 
-                      safesearch: str = "moderate", region: str = "wt-wt",
-                      timeout: int = 15) -> List[Dict[str, str]]:
+
+def search_duckduckgo(
+    query: str, max_results: int = 5, safesearch: str = "moderate", region: str = "wt-wt", timeout: int = 15
+) -> list[dict[str, str]]:
     """
     Search DuckDuckGo using the duckduckgo_search library and return parsed results.
-    
+
     Args:
         query: The search query string
         max_results: Maximum number of results to return
         safesearch: Safe search setting ('on', 'moderate', 'off')
         region: Region code for localized results (default: wt-wt for no region)
         timeout: Request timeout in seconds
-        
+
     Returns:
-        List of dictionaries containing search results with title, url, and snippet
+        list of dictionaries containing search results with title, url, and snippet
     """
     # Validate parameters
     if not query or not isinstance(query, str):
         raise ValueError("Query must be a non-empty string")
-        
+
     if not isinstance(max_results, int) or max_results <= 0:
         raise ValueError("max_results must be a positive integer")
-    
+
     # Validate safesearch parameter
     valid_safesearch = ["on", "moderate", "off"]
     if safesearch not in valid_safesearch:
         logger.warning(f"Invalid safesearch value: '{safesearch}'. Using 'moderate' instead.")
         safesearch = "moderate"
-    
+
     try:
         # Using the DDGS class from duckduckgo_search package to perform the search
         ddgs = DDGS(timeout=timeout)
-        
+
         # Get search results - the text method returns results in the format we need
         # See: https://github.com/deedy5/duckduckgo_search
         results = ddgs.text(
-            keywords=query,
+            query=query,
             region=region,
             safesearch=safesearch,
             max_results=max_results,
-            backend="lite" if len(query) > 100 else "html"  # Use lite backend for long queries
+            backend="lite" if len(query) > QUERY_LENGTH_LITE_BACKEND_THRESHOLD else "html",  # Use lite backend for long queries
         )
-        
-        # Transform the results to the expected format
-        formatted_results = []
-        for result in results:
-            formatted_results.append({
-                'title': result.get('title', ''),
-                'url': result.get('href', ''),  # duckduckgo-search uses 'href' for the URL
-                'snippet': result.get('body', '')  # duckduckgo-search uses 'body' for snippets
-            })
-            
+
+        formatted_results = _format_ddg_results(results)
         return formatted_results
-    
-    except DuckDuckGoSearchException as e:
+
+    except DDGSException as e:
         # Handle specific exceptions from the duckduckgo-search library
         logger.error(f"DuckDuckGo search error: {str(e)}")
         # Try using the lite backend as a fallback
@@ -88,21 +96,14 @@ def search_duckduckgo(query: str, max_results: int = 5,
                 logger.info("Retrying with lite backend as fallback")
                 ddgs = DDGS(timeout=timeout)
                 results = ddgs.text(
-                    keywords=query,
+                    query=query,
                     region=region,
                     safesearch=safesearch,
                     max_results=max_results,
-                    backend="lite"
+                    backend="lite",
                 )
-                
-                # Transform the results
-                formatted_results = []
-                for result in results:
-                    formatted_results.append({
-                        'title': result.get('title', ''),
-                        'url': result.get('href', ''),
-                        'snippet': result.get('body', '')
-                    })
+
+                formatted_results = _format_ddg_results(results)
                 return formatted_results
         except Exception as inner_e:
             logger.error(f"Fallback search failed: {str(inner_e)}")
@@ -111,76 +112,77 @@ def search_duckduckgo(query: str, max_results: int = 5,
         logger.error(f"Unexpected error during search: {str(e)}")
         return []
 
+
 @mcp.tool()
-def duckduckgo_search(query: str, max_results: int = 5, 
-                      safesearch: str = "moderate") -> List[Dict[str, str]]:
+def duckduckgo_search(query: str, max_results: int = 5, safesearch: str = "moderate") -> list[dict[str, str]]:
     """
     Search the web using DuckDuckGo.
-    
+
     Args:
         query: The search query
         max_results: Maximum number of search results to return (default: 5)
         safesearch: Safe search setting ('on', 'moderate', 'off'; default: 'moderate')
-        
+
     Returns:
-        List of search results with title, URL, and snippet
+        list of search results with title, URL, and snippet
     """
     # Validate parameters
     if not query:
         raise ValueError("Missing required parameter: query")
-    
+
     try:
         # Validate max_results
         if not isinstance(max_results, int):
             max_results = int(max_results)
-            
+
         if max_results <= 0:
             raise ValueError("max_results must be a positive integer")
     except (ValueError, TypeError):
         raise ValueError("max_results must be a valid positive integer")
-    
+
     # Perform search
     try:
         results = search_duckduckgo(query, max_results, safesearch)
-        
+
         # Check if we got any results
         if not results:
             logger.warning(f"No results found for query: '{query}'")
-            
+
         # Return results
         return results
     except Exception as e:
         logger.error(f"Error in duckduckgo_search: {str(e)}")
         raise
 
+
 def main():
     """Main function for CLI usage"""
     parser = argparse.ArgumentParser(description="Search DuckDuckGo from the command line")
-    parser.add_argument("query", help="The search query", nargs='+')
-    parser.add_argument("--max-results", "-n", type=int, default=5, 
-                        help="Maximum number of results (default: 5)")
-    parser.add_argument("--safesearch", choices=["on", "moderate", "off"], 
-                        default="moderate", help="Safe search setting (default: moderate)")
+    parser.add_argument("query", help="The search query", nargs="+")
+    parser.add_argument("--max-results", "-n", type=int, default=5, help="Maximum number of results (default: 5)")
+    parser.add_argument(
+        "--safesearch",
+        choices=["on", "moderate", "off"],
+        default="moderate",
+        help="Safe search setting (default: moderate)",
+    )
     parser.add_argument("--debug", action="store_true", help="Enable debug logging")
-    
+
     args = parser.parse_args()
-    
+
     # Set debug logging if requested
     if args.debug:
         logging.getLogger().setLevel(logging.DEBUG)
-        
+
     # Join query arguments to handle quotes properly
     query = " ".join(args.query)
-    
+
     # Perform search
-    results = search_duckduckgo(
-        query=query,
-        max_results=args.max_results,
-        safesearch=args.safesearch
-    )
-    
+    results = search_duckduckgo(query=query, max_results=args.max_results, safesearch=args.safesearch)
+
     # Output results as JSON
     print(json.dumps(results, indent=2, ensure_ascii=False))
+
 
 if __name__ == "__main__":
     main()

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 
 [[package]]
@@ -230,11 +230,25 @@ toml = [
 ]
 
 [[package]]
+name = "ddgs"
+version = "9.5.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "lxml" },
+    { name = "primp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/67/65/6c5c1b2acf2a902b340c9a0df5051a4af2384a952bc29407c4ab53c267eb/ddgs-9.5.2.tar.gz", hash = "sha256:1011cb0ad2329163c9f92b61231c654a8abe0bfdc9a3877dbf45bf41bf6a11ba", size = 32585, upload-time = "2025-08-05T21:11:51.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ff/e2/8feccc47acfc1ada5e63d037aa5f345eb92503d851b0c5e461bf05fbdfa8/ddgs-9.5.2-py3-none-any.whl", hash = "sha256:3685246763426f6bca06db709dc4464db7940b8a418b56880f0ae41c3480e0c3", size = 36350, upload-time = "2025-08-05T21:11:50.177Z" },
+]
+
+[[package]]
 name = "duckduckgo-mcp"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },
-    { name = "duckduckgo-search" },
+    { name = "ddgs" },
     { name = "fastmcp" },
     { name = "mcp" },
     { name = "requests" },
@@ -254,7 +268,7 @@ dev = [
 requires-dist = [
     { name = "beautifulsoup4", specifier = ">=4.11.0" },
     { name = "black", marker = "extra == 'dev'", specifier = ">=23.0.0" },
-    { name = "duckduckgo-search", specifier = ">=8.0.2" },
+    { name = "ddgs", specifier = ">=9.5.2" },
     { name = "fastmcp", specifier = ">=2.3.4" },
     { name = "isort", marker = "extra == 'dev'", specifier = ">=5.0.0" },
     { name = "mcp", specifier = ">=1.9.0" },
@@ -265,20 +279,6 @@ requires-dist = [
     { name = "urllib3", specifier = ">=1.26.0,<2.0.0" },
 ]
 provides-extras = ["dev"]
-
-[[package]]
-name = "duckduckgo-search"
-version = "8.0.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "lxml" },
-    { name = "primp" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ad/c0/e18c2148d33a9d87f6a0cc00acba30b4e547be0f8cb85ccb313a6e8fbac7/duckduckgo_search-8.0.2.tar.gz", hash = "sha256:3109a99967b29cab8862823bbe320d140d5c792415de851b9d6288de2311b3ec", size = 21807, upload-time = "2025-05-15T08:43:25.311Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/bf/6c/e36d22e76f4aa4e1ea7ea9b443bd49b5ffd2f13d430840f47e35284f797a/duckduckgo_search-8.0.2-py3-none-any.whl", hash = "sha256:b5ff8b6b8f169b8e1b15a788a5749aa900ebcefd6e1ab485787582f8d5b4f1ef", size = 18184, upload-time = "2025-05-15T08:43:23.713Z" },
-]
 
 [[package]]
 name = "exceptiongroup"


### PR DESCRIPTION
Faced some warning issue as shown below. <https://pypi.org/project/duckduckgo-search/>

```
:warning: This package (duckduckgo_search) has been renamed to ddgs! Use pip install ddgs instead.
```