### PR TITLE
feat: add LLM-friendly output format and deployment support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,51 @@
+# Git
+.git
+.gitignore
+
+# Python
+__pycache__
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Virtual environments
+.venv
+venv/
+ENV/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# Testing
+.pytest_cache/
+.coverage
+htmlcov/
+.mypy_cache/
+
+# Documentation
+docs/_build/
+
+# Local development
+*.log
+.env
+.env.*
+TODO.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,5 +19,9 @@ COPY src/ ./src/
 # Install the package
 RUN pip install --no-cache-dir .
 
+# Create non-root user for security
+RUN useradd --create-home --shell /bin/bash appuser
+USER appuser
+
 # Run the MCP server
 ENTRYPOINT ["duckduckgo-mcp", "serve"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+# Version for setuptools_scm (required since .git is not copied)
+# Override at build time with: docker build --build-arg VERSION=x.y.z
+ARG VERSION=0.0.0
+ENV SETUPTOOLS_SCM_PRETEND_VERSION=${VERSION}
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gcc \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy project files
+COPY pyproject.toml README.md ./
+COPY src/ ./src/
+
+# Install the package
+RUN pip install --no-cache-dir .
+
+# Run the MCP server
+ENTRYPOINT ["duckduckgo-mcp", "serve"]

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,45 @@
+# Features to Implement
+
+## High Priority (Completed)
+
+### 1. LLM-Friendly Output Format Option
+- [x] Add `output_format` parameter to `duckduckgo_search` tool
+  - `"json"` (default) - current behavior, returns list of dicts
+  - `"text"` - natural language formatted output for LLMs
+- [x] Include position numbering in results
+- [x] Format as numbered list with title, URL, and summary
+- [x] Add helpful "no results" message with suggestions
+
+### 2. Dockerfile
+- [x] Create `Dockerfile` for containerized deployment
+- [x] Use Python 3.12-slim base image
+- [x] Ensure proper entrypoint for MCP server mode
+- [x] Add to `.dockerignore` for clean builds
+
+### 3. Smithery Configuration
+- [x] Create `smithery.yaml` for MCP ecosystem discoverability
+- [x] Enable one-click installation via `npx @smithery/cli install`
+- [x] Add Smithery badge to README.md
+
+## Medium Priority
+
+### 4. Explicit Rate Limiting
+- [ ] Add configurable `RateLimiter` class
+- [ ] Apply rate limiting to Jina fetch (external API dependency)
+- [ ] Log when rate limiting is active
+- [ ] Make limits configurable (default: 30 req/min search, 20 req/min fetch)
+
+### 5. Better Error Messaging
+- [x] Improve "no results" message with actionable suggestions (done in text format)
+- [ ] Add context about potential causes (rate limiting, query issues)
+- [ ] Include truncation details (original vs truncated length)
+
+### 6. Position Numbering in Results
+- [x] Position numbering included in text output format
+- [ ] Add `position` field to JSON result dictionaries (optional)
+
+## Low Priority (Nice to Have)
+
+### 7. Enhanced Truncation Feedback
+- [ ] Show original content length when truncating
+- [ ] Format: `"... (truncated at {max_length} chars, original: {original_length})"`

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,26 @@
+# Smithery configuration file: https://smithery.ai/docs/config#smitheryyaml
+
+build:
+  dockerBuildPath: .
+
+startCommand:
+  type: stdio
+  configSchema:
+    # JSON Schema defining the configuration options for the MCP.
+    type: object
+    properties:
+      debug:
+        type: boolean
+        description: Enable debug logging
+        default: false
+  commandFunction:
+    # A JS function that produces the CLI command based on the given config to start the MCP on stdio.
+    |-
+    (config) => ({
+      command: 'uvx',
+      args: config.debug
+        ? ['duckduckgo-mcp', 'serve', '--debug']
+        : ['duckduckgo-mcp', 'serve']
+    })
+  exampleConfig:
+    debug: false


### PR DESCRIPTION
## Summary

- Add `output_format` parameter to `duckduckgo_search` tool with two modes:
  - `json` (default): Returns list of dicts (backward compatible)
  - `text`: Returns LLM-friendly formatted string with numbered results
- Add Docker support for containerized deployment
- Add Smithery configuration for MCP ecosystem discoverability

## Changes

### New Features
- **LLM-friendly output format**: Search results can now be returned as formatted text optimized for LLM consumption, with position numbering and helpful "no results" messaging
- **Docker support**: New `Dockerfile` and `.dockerignore` for containerized deployment
- **Smithery integration**: `smithery.yaml` enables one-click installation via `npx @smithery/cli install`

### Files Changed
| File | Change |
|------|--------|
| `src/duckduckgo_mcp/duckduckgo_search.py` | Added `output_format` parameter and `_format_results_as_text()` |
| `src/duckduckgo_mcp/cli.py` | Added `--output-format` CLI flag |
| `Dockerfile` | New - containerized deployment |
| `.dockerignore` | New - clean Docker builds |
| `smithery.yaml` | New - Smithery MCP registry config |
| `README.md` | Updated docs with new features |

## Test plan

- [x] Test text output format: `duckduckgo-mcp search "query" --output-format text`
- [x] Test JSON output format (backward compatibility): `duckduckgo-mcp search "query" --output-format json`
- [x] Test empty results message formatting
- [x] Test Docker build: `docker build --build-arg VERSION=2.0.2 -t duckduckgo-mcp .`
- [x] Verify Docker image runs: `docker run --rm --entrypoint duckduckgo-mcp duckduckgo-mcp:latest version`
- [x] Validate smithery.yaml syntax

🤖 Generated with [Claude Code](https://claude.com/claude-code)