### PR TITLE
docs: add cross-agent npx install path for skills

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "forager-skills",
+  "skills": [
+    "./skills/web-research",
+    "./skills/fact-check",
+    "./skills/news-monitor",
+    "./skills/competitive-intel",
+    "./skills/tech-advisor"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Python Version](https://img.shields.io/pypi/pyversions/web-forager?style=flat-square)](https://pypi.org/project/web-forager/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=flat-square)](https://opensource.org/licenses/MIT)
 [![Downloads](https://static.pepy.tech/badge/web-forager/month)](https://pepy.tech/project/web-forager)
+[![skills.sh](https://skills.sh/b/CyranoB/web-forager)](https://skills.sh/CyranoB/web-forager)
 
 *The thing about information on the web is that it doesn't want to be found. It wants to hide behind cookie banners, keep itself to itself, and generally behave like a cat that knows it's time for the vet. Web Forager is the sort of dogged, slightly grubby assistant who goes out there anyway — accompanied by a duck of questionable temperament — rummages through DuckDuckGo, grabs pages directly when it can, and calls in Jina Reader when things get complicated. The results come back neatly converted for LLM consumption, which is to say, in a format that would make a librarian weep with either joy or despair, depending on the librarian.*
 
@@ -14,6 +15,25 @@ The skills search DuckDuckGo, monitor news, fetch pages, and synthesize cited an
 
 Default usage is skill-first. You do not need to configure an MCP server to use the
 research workflows.
+
+## Quickstart
+
+Install all five skills with one command. It works for 50+ coding agents:
+
+```bash
+npx skills@latest add CyranoB/web-forager
+```
+
+The installer detects your agents, asks which skills you want, and places them in
+the right location.
+
+Common variations:
+
+```bash
+npx skills@latest add CyranoB/web-forager --list
+npx skills@latest add CyranoB/web-forager --skill web-research
+npx skills@latest add CyranoB/web-forager --skill '*' -a claude-code -a codex -y
+```
 
 ## Install For Your Coding Tool
 
@@ -33,6 +53,8 @@ Install all five skills from the plugin marketplace:
 
 Restart Claude Code, then check `/skills`.
 
+The Quickstart command above is also available as a cross-agent install path.
+
 MCP-only fallback:
 
 ```bash
@@ -44,12 +66,16 @@ claude mcp add --transport stdio web-forager -- uvx --python ">=3.10,<3.14" web-
 <details>
 <summary><strong>Codex</strong></summary>
 
-Install the skills manually:
+Install the skills for the current project:
 
 ```bash
-git clone https://github.com/CyranoB/web-forager.git
-mkdir -p ~/.codex/skills
-cp -R web-forager/skills/* ~/.codex/skills/
+npx skills@latest add CyranoB/web-forager -a codex
+```
+
+Install globally instead:
+
+```bash
+npx skills@latest add CyranoB/web-forager -a codex -g
 ```
 
 MCP-only fallback:
@@ -76,68 +102,64 @@ MCP-only fallback: configure a local MCP server with the standard config below.
 <details>
 <summary><strong>Gemini CLI</strong></summary>
 
-If you want MCP tools:
+Install the skills for the current project:
+
+```bash
+npx skills@latest add CyranoB/web-forager -a gemini-cli
+```
+
+Install globally instead:
+
+```bash
+npx skills@latest add CyranoB/web-forager -a gemini-cli -g
+```
+
+MCP-only fallback:
 
 ```bash
 gemini mcp add web-forager uvx --python ">=3.10,<3.14" web-forager serve
 ```
-
-For skills, copy the folders from `skills/` into the skills location supported by
-your Gemini environment.
 
 </details>
 
 <details>
 <summary><strong>Pi Coding Agent</strong></summary>
 
-Install globally for Pi:
+Install the skills for the current project:
 
 ```bash
-git clone https://github.com/CyranoB/web-forager.git
-mkdir -p ~/.pi/agent/skills
-cp -R web-forager/skills/* ~/.pi/agent/skills/
+npx skills@latest add CyranoB/web-forager -a pi
 ```
 
-Or install only for the current project:
+Install globally instead:
 
 ```bash
-git clone https://github.com/CyranoB/web-forager.git
-mkdir -p .pi/skills
-cp -R web-forager/skills/* .pi/skills/
+npx skills@latest add CyranoB/web-forager -a pi -g
 ```
 
-Pi also discovers skills from the generic Agent Skills directories:
-
-```bash
-mkdir -p ~/.agents/skills
-cp -R web-forager/skills/* ~/.agents/skills/
-```
-
-For one-off sessions, pass a skill path explicitly:
+For one-off sessions from a local checkout, pass a skill path explicitly:
 
 ```bash
 pi --skill web-forager/skills/web-research
 ```
+
+MCP-only fallback: configure a local MCP server with the standard config below.
 
 </details>
 
 <details>
 <summary><strong>Kiro CLI</strong></summary>
 
-Install globally for all Kiro CLI projects:
+Install the skills for the current workspace:
 
 ```bash
-git clone https://github.com/CyranoB/web-forager.git
-mkdir -p ~/.kiro/skills
-cp -R web-forager/skills/* ~/.kiro/skills/
+npx skills@latest add CyranoB/web-forager -a kiro-cli
 ```
 
-Or install only for the current workspace:
+Install globally instead:
 
 ```bash
-git clone https://github.com/CyranoB/web-forager.git
-mkdir -p .kiro/skills
-cp -R web-forager/skills/* .kiro/skills/
+npx skills@latest add CyranoB/web-forager -a kiro-cli -g
 ```
 
 Kiro's default agent loads skills from both locations automatically. For custom
@@ -168,22 +190,17 @@ https://github.com/CyranoB/web-forager
 
 ### Individual Skills
 
-For any Agent Skills-compatible tool, install one skill folder directly. For example:
+For any Agent Skills-compatible tool, install one skill by name:
 
 ```bash
-claude install-skill github:CyranoB/web-forager/skills/web-research
+npx skills@latest add CyranoB/web-forager --skill web-research
 ```
 
-Or install from a local checkout:
+Direct skill URLs also work:
 
 ```bash
-git clone https://github.com/CyranoB/web-forager.git
-cd web-forager
-claude install-skill ./skills/web-research
+npx skills@latest add https://github.com/CyranoB/web-forager/tree/main/skills/web-research
 ```
-
-For agents without `claude install-skill`, copy a folder from `skills/` into your
-agent's skills directory.
 
 ## Use The Skills
 

--- a/scripts/link-skills.sh
+++ b/scripts/link-skills.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Links all skills in this repository to a local Claude Code skills directory
+# for dogfooding edits without publishing a new version.
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+DEST="${SKILLS_DEST:-$HOME/.claude/skills}"
+
+resolve_path() {
+  if command -v realpath >/dev/null 2>&1; then
+    realpath "$1"
+  elif command -v greadlink >/dev/null 2>&1; then
+    greadlink -f "$1"
+  else
+    readlink -f "$1"
+  fi
+}
+
+# If the destination directory itself points into this repo, writing per-skill
+# symlinks would pollute the working copy. Stop instead.
+if [ -L "$DEST" ]; then
+  resolved="$(resolve_path "$DEST")"
+  case "$resolved" in
+    "$REPO"|"$REPO"/*)
+      echo "error: $DEST is a symlink into this repo ($resolved)." >&2
+      echo "Remove it or set SKILLS_DEST to a real directory, then re-run." >&2
+      exit 1
+      ;;
+  esac
+fi
+
+mkdir -p "$DEST"
+
+find_skill_files() {
+  find "$REPO/skills" -name SKILL.md -not -path '*/node_modules/*' -not -path '*/deprecated/*' -print0
+}
+
+while IFS= read -r -d '' skill_md; do
+  name="$(basename "$(dirname "$skill_md")")"
+  target="$DEST/$name"
+
+  if [ -e "$target" ] && [ ! -L "$target" ]; then
+    echo "error: $target already exists and is not a symlink." >&2
+    echo "Move or remove it before linking $name." >&2
+    exit 1
+  fi
+done < <(find_skill_files)
+
+while IFS= read -r -d '' skill_md; do
+  src="$(dirname "$skill_md")"
+  name="$(basename "$src")"
+  target="$DEST/$name"
+
+  ln -sfn "$src" "$target"
+  echo "linked $name -> $src"
+done < <(find_skill_files)


### PR DESCRIPTION
## Summary
- Replace per-agent `git clone` + `cp -R` instructions with `npx skills@latest add` commands across Claude Code, Codex, Gemini CLI, Pi, and Kiro CLI sections, and add a top-level Quickstart that documents the one-command install.
- Add `.claude-plugin/plugin.json` so the `skills` installer can enumerate the five skill folders.
- Add `scripts/link-skills.sh` to symlink the in-repo skills into `~/.claude/skills` for dogfooding.

## Test plan
- [x] Run `npx skills@latest add CyranoB/web-forager --list` against the pushed branch and confirm all five skills are listed.
- [ ] Run `scripts/link-skills.sh` against a clean `~/.claude/skills` and confirm symlinks are created for each skill.