### PR TITLE
feat: add Conductor setup script and fix SonarQube shell issues

### DIFF
--- a/conductor.json
+++ b/conductor.json
@@ -1,0 +1,6 @@
+{
+  "scripts": {
+    "setup": "./scripts/conductor/setup"
+  },
+  "runScriptMode": "nonconcurrent"
+}

--- a/scripts/conductor/setup
+++ b/scripts/conductor/setup
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ─── Link shared env files from Conductor root ──────────────────
+for f in .env .env.local; do
+  src="${CONDUCTOR_ROOT_PATH:-}/$f"
+  if [[ -n "${CONDUCTOR_ROOT_PATH:-}" && -f "$src" && ! -L "$f" && ! -e "$f" ]]; then
+    ln -s "$src" "$f"
+  fi
+done
+
+# ─── Check for uv ───────────────────────────────────────────────
+if ! command -v uv >/dev/null 2>&1; then
+  echo "Error: uv is required but not installed." >&2
+  echo "Install with: curl -LsSf https://astral.sh/uv/install.sh | sh" >&2
+  exit 1
+fi
+
+# ─── Create venv if missing ──────────────────────────────────────
+if [[ ! -d .venv ]]; then
+  uv venv
+fi
+
+# ─── Install project + dev dependencies ─────────────────────────
+uv pip install -e ".[dev]"
+
+# ─── Verify installation ────────────────────────────────────────
+.venv/bin/web-forager version

--- a/scripts/link-skills.sh
+++ b/scripts/link-skills.sh
@@ -8,24 +8,27 @@ REPO="$(cd "$(dirname "$0")/.." && pwd)"
 DEST="${SKILLS_DEST:-$HOME/.claude/skills}"
 
 resolve_path() {
+  local path="$1"
   if command -v realpath >/dev/null 2>&1; then
-    realpath "$1"
+    realpath "$path"
   elif command -v greadlink >/dev/null 2>&1; then
-    greadlink -f "$1"
+    greadlink -f "$path"
   else
-    readlink -f "$1"
+    readlink -f "$path"
   fi
 }
 
 # If the destination directory itself points into this repo, writing per-skill
 # symlinks would pollute the working copy. Stop instead.
-if [ -L "$DEST" ]; then
+if [[ -L "$DEST" ]]; then
   resolved="$(resolve_path "$DEST")"
   case "$resolved" in
     "$REPO"|"$REPO"/*)
       echo "error: $DEST is a symlink into this repo ($resolved)." >&2
       echo "Remove it or set SKILLS_DEST to a real directory, then re-run." >&2
       exit 1
+      ;;
+    *)
       ;;
   esac
 fi
@@ -40,7 +43,7 @@ while IFS= read -r -d '' skill_md; do
   name="$(basename "$(dirname "$skill_md")")"
   target="$DEST/$name"
 
-  if [ -e "$target" ] && [ ! -L "$target" ]; then
+  if [[ -e "$target" ]] && [[ ! -L "$target" ]]; then
     echo "error: $target already exists and is not a symlink." >&2
     echo "Move or remove it before linking $name." >&2
     exit 1


### PR DESCRIPTION
## Summary

- Add `conductor.json` and `scripts/conductor/setup` to automate workspace provisioning: links shared env files, creates a venv via `uv`, installs project + dev dependencies, and verifies the CLI works.
- Fix all 7 SonarQube findings in `scripts/link-skills.sh`: replace `[ ]` with `[[ ]]` for conditionals, assign positional parameters to local variables in `resolve_path()`, and add a default `*)` case to the `case` statement.
- Proactively apply the same `[[ ]]` fix to the new `scripts/conductor/setup` script.

## Test plan

- [x] Run `./scripts/conductor/setup` in a clean workspace and verify `.venv` is created with all dependencies
- [x] Run `./scripts/link-skills.sh` and verify skills are symlinked correctly
- [x] Confirm SonarQube no longer reports issues on the changed files