### PR TITLE
feat: rename web-research skill to deep-research

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -15,7 +15,7 @@
       "source": "./",
       "strict": false,
       "skills": [
-        "./skills/web-research",
+        "./skills/deep-research",
         "./skills/fact-check",
         "./skills/news-monitor",
         "./skills/competitive-intel",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "forager-skills",
   "skills": [
-    "./skills/web-research",
+    "./skills/deep-research",
     "./skills/fact-check",
     "./skills/news-monitor",
     "./skills/competitive-intel",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Web Forager — a search-and-fetch toolkit for AI agents with three MCP capabili
 - URL fetch + conversion via direct HTTP/trafilatura (Jina Reader as fallback)
 
 Also includes five Agent Skills (in `skills/`) that orchestrate search + fetch into
-specialized workflows: web-research, fact-check, news-monitor, competitive-intel, tech-advisor.
+specialized workflows: deep-research, fact-check, news-monitor, competitive-intel, tech-advisor.
 
 Implements MCP over STDIO using FastMCP.
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Common variations:
 
 ```bash
 npx skills@latest add CyranoB/web-forager --list
-npx skills@latest add CyranoB/web-forager --skill web-research
+npx skills@latest add CyranoB/web-forager --skill deep-research
 npx skills@latest add CyranoB/web-forager --skill '*' -a claude-code -a codex -y
 ```
 
@@ -140,7 +140,7 @@ npx skills@latest add CyranoB/web-forager -a pi -g
 For one-off sessions from a local checkout, pass a skill path explicitly:
 
 ```bash
-pi --skill web-forager/skills/web-research
+pi --skill web-forager/skills/deep-research
 ```
 
 MCP-only fallback: configure a local MCP server with the standard config below.
@@ -193,13 +193,13 @@ https://github.com/CyranoB/web-forager
 For any Agent Skills-compatible tool, install one skill by name:
 
 ```bash
-npx skills@latest add CyranoB/web-forager --skill web-research
+npx skills@latest add CyranoB/web-forager --skill deep-research
 ```
 
 Direct skill URLs also work:
 
 ```bash
-npx skills@latest add https://github.com/CyranoB/web-forager/tree/main/skills/web-research
+npx skills@latest add https://github.com/CyranoB/web-forager/tree/main/skills/deep-research
 ```
 
 ## Use The Skills
@@ -221,7 +221,7 @@ Should we adopt Bun for a production Node service?
 
 | Skill | Use it for | Output |
 | --- | --- | --- |
-| [web-research](skills/web-research/) | General research, lookups, deep dives | Adaptive report with citations |
+| [deep-research](skills/deep-research/) | General research, lookups, deep dives | Adaptive report with citations |
 | [fact-check](skills/fact-check/) | Verifying a specific claim | Verdict with supporting and contradicting evidence |
 | [news-monitor](skills/news-monitor/) | Recent news and updates | Chronological briefing |
 | [competitive-intel](skills/competitive-intel/) | Market maps and competitor analysis | Landscape or positioning report |

--- a/skills/deep-research/SKILL.md
+++ b/skills/deep-research/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: web-research
+name: deep-research
 license: MIT
 metadata:
   author: CyranoB
@@ -19,7 +19,7 @@ description: >
   sources — unless the user explicitly asks to search the web.
 ---
 
-# Web Research
+# Deep Research
 
 This skill guides you through a structured deep research workflow: multi-angle search,
 selective full-page fetching, and synthesis into a polished, cited report.
@@ -42,14 +42,14 @@ for r in results:
 PY
 ```
 
-**Fetch** — call Jina Reader directly to get a URL as clean markdown:
+**Fetch** — run the packaged Web Forager CLI with uvx:
+```bash
+uvx --python '>=3.10,<3.14' web-forager fetch "https://example.com" --format markdown
+```
+
+If `uvx` cannot run the packaged CLI, call Jina Reader directly:
 ```bash
 curl -s "https://r.jina.ai/https://example.com"
-```
-Or in Python:
-```python
-import requests
-content = requests.get(f"https://r.jina.ai/{url}").text
 ```
 No API key needed.
 
@@ -91,7 +91,7 @@ lets them redirect you if you've chosen poorly.
 
 ### Step 4 — Fetch full content
 
-Fetch each selected URL using the Jina Reader method above. Use markdown format (default).
+Fetch each selected URL using the uvx fetch command above. Use markdown format (default).
 If a fetch fails, skip that URL and note it in your sources section.
 
 For very long pages, focus on the most relevant sections rather than including everything.

--- a/src/web_forager/_version.py
+++ b/src/web_forager/_version.py
@@ -18,7 +18,7 @@ version_tuple: tuple[int | str, ...]
 commit_id: str | None
 __commit_id__: str | None
 
-__version__ = version = '3.0.1.post7'
-__version_tuple__ = version_tuple = (3, 0, 1, 'post7')
+__version__ = version = '3.0.1.post9'
+__version_tuple__ = version_tuple = (3, 0, 1, 'post9')
 
-__commit_id__ = commit_id = 'gcda53c398'
+__commit_id__ = commit_id = 'g5da99bc22'

--- a/src/web_forager/_version.py
+++ b/src/web_forager/_version.py
@@ -18,7 +18,7 @@ version_tuple: tuple[int | str, ...]
 commit_id: str | None
 __commit_id__: str | None
 
-__version__ = version = '3.0.1.post4'
-__version_tuple__ = version_tuple = (3, 0, 1, 'post4')
+__version__ = version = '3.0.1.post7'
+__version_tuple__ = version_tuple = (3, 0, 1, 'post7')
 
-__commit_id__ = commit_id = 'g006c4b26a'
+__commit_id__ = commit_id = 'gcda53c398'


### PR DESCRIPTION
## Summary

- Renames the `web-research` skill to `deep-research` to better reflect its deep research workflow
- Updates the Fetch tool section to use `uvx web-forager fetch` as the primary method (matching how Search already worked), with Jina Reader as fallback
- Updates all references in plugin.json, marketplace.json, README.md, and CLAUDE.md

## Test plan

- [ ] Verify `npx skills@latest add CyranoB/web-forager --skill deep-research` installs correctly
- [ ] Confirm the skill triggers on research-related prompts
- [ ] Test `uvx web-forager fetch` works as the default fetch method